### PR TITLE
Capturelogic

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,14 +1,16 @@
 class Game < ApplicationRecord
   # belongs_to :black_player, class_name: 'Player'
   has_many :pieces
-
+  has_many :players
   belongs_to :white_player, class_name: "User" 
   belongs_to :black_player, class_name: "User", optional: true 
-  before_save :start_game_when_black_player_is_added 
+  before_save :start_game_when_black_player_is_added
+  after_create :populate
+
   scope :available, -> {where("total_players = 1")}
-  has_many :players
-  belongs_to :user
-  after_create :current_user_is_white_player
+
+  #belongs_to :user
+  #after_create :current_user_is_white_player
 
 
   # to initialize each game with the white_player as the user who created the game
@@ -28,10 +30,6 @@ class Game < ApplicationRecord
   
   def start_game_when_black_player_is_added
     self.state = "white_turn" if state == "pending" && black_player_id.present?
-
-
-  def current_user_is_white_player
-    self.white_player_id = user_id
   end
   
   def player_turn

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -148,6 +148,19 @@ class Piece < ApplicationRecord
     in_bounds?(x_target, y_target)
   end
 
+  def is_capturable?(x_target, y_target)
+    if game.square_occupied?(x_target, y_target)
+      piece_array = game.pieces.active.where({x: x_target, y: y_target})
+      piece_color = ''
+      piece_array.each { |piece| piece_color = piece.color }
+      if self.color == piece_color
+        false
+      else
+        true
+      end
+    end
+  end
+
   private
 
   def in_bounds?(x_target, y_target)

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -150,14 +150,13 @@ class Piece < ApplicationRecord
 
   def is_capturable?(x_target, y_target)
     if game.square_occupied?(x_target, y_target)
-      piece_array = game.pieces.active.where({x: x_target, y: y_target})
-      piece_color = ''
-      piece_array.each { |piece| piece_color = piece.color }
-      if self.color == piece_color
-        false
-      else
-        true
-      end
+      self.color == target_piece(x_target, y_target).color ? false : true
+    end
+  end
+
+  def captured!(x_target, y_target)
+    if is_capturable?(x_target, y_target)
+      target_piece(x_target, y_target).update_attributes(captured: true, x: 0, y: 0)
     end
   end
 
@@ -169,6 +168,10 @@ class Piece < ApplicationRecord
 
   def in_range?(x_target, y_target)
     true
+  end
+
+  def target_piece(x_target, y_target)
+    game.pieces.active.where({x: x_target, y: y_target}).first
   end
 end
 

--- a/db/migrate/20171231230526_add_default_value_to_pieces.rb
+++ b/db/migrate/20171231230526_add_default_value_to_pieces.rb
@@ -1,0 +1,5 @@
+class AddDefaultValueToPieces < ActiveRecord::Migration[5.1]
+  def change
+    change_column :pieces, :captured, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171213233138) do
+ActiveRecord::Schema.define(version: 20171231230526) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,10 +20,10 @@ ActiveRecord::Schema.define(version: 20171213233138) do
     t.boolean "finished"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "total_players"
     t.bigint "white_player_id"
     t.bigint "black_player_id"
     t.bigint "user_id"
-    t.integer "total_players"
   end
 
   create_table "pieces", force: :cascade do |t|
@@ -34,7 +34,7 @@ ActiveRecord::Schema.define(version: 20171213233138) do
     t.string "color"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "captured"
+    t.boolean "captured", default: false
     t.index ["game_id"], name: "index_pieces_on_game_id"
   end
 

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -88,4 +88,20 @@ RSpec.describe Piece, type: :model do
       expect(result).to eq false
     end
   end
+
+  describe 'capture' do
+    it '#is_capturable? returns true if target can be captured' do
+      game = FactoryBot.create(:game)
+      piece = FactoryBot.build(:piece, game_id: game.id, x: 3, y: 3)
+      result = piece.is_capturable?(3, 7)
+      expect(result).to eq true
+    end
+
+    it '#is_capturable? returns false if target cannot be captured' do
+      game = FactoryBot.create(:game)
+      piece = FactoryBot.build(:piece, game_id: game.id, x: 3, y: 3)
+      result = piece.is_capturable?(3, 2)
+      expect(result).to eq false
+    end
+  end
 end

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -96,15 +96,15 @@ RSpec.describe Piece, type: :model do
       x_target = 3
       y_target = 7
       result = piece.is_capturable?(x_target, y_target)
-      piece_array = game.pieces.active.where({x: x_target, y: y_target})
-      target_piece = piece_array[0]
       expect(result).to eq true
     end
 
     it '#is_capturable? returns false if target cannot be captured' do
       game = FactoryBot.create(:game)
       piece = FactoryBot.build(:piece, game_id: game.id, x: 3, y: 3)
-      result = piece.is_capturable?(3, 2)
+      x_target = 3
+      y_target = 2
+      result = piece.is_capturable?(x_target, y_target)
       expect(result).to eq false
     end
 
@@ -113,8 +113,7 @@ RSpec.describe Piece, type: :model do
       piece = FactoryBot.build(:piece, game_id: game.id, x: 3, y: 3)
       x_target = 3
       y_target = 7
-      piece_array = game.pieces.active.where({x: x_target, y: y_target})
-      target_piece = piece_array[0]
+      target_piece = game.pieces.active.where({x: x_target, y: y_target}).first
       piece.captured!(x_target, y_target)
       target_piece.reload
       expect(target_piece.captured).to eq true
@@ -122,7 +121,17 @@ RSpec.describe Piece, type: :model do
       expect(target_piece.y).to eq 0
     end
 
-    xit '#captured! does not update target piece attributes if target is not capturable' do
+    it '#captured! does not update target piece attributes if target is not capturable' do
+      game = FactoryBot.create(:game)
+      piece = FactoryBot.build(:piece, game_id: game.id, x: 3, y: 3)
+      x_target = 3
+      y_target = 2
+      target_piece = game.pieces.active.where({x: x_target, y: y_target}).first
+      piece.captured!(x_target, y_target)
+      target_piece.reload
+      expect(target_piece.captured).to eq false
+      expect(target_piece.x).to eq x_target
+      expect(target_piece.y).to eq y_target
     end
 
   end

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -93,7 +93,11 @@ RSpec.describe Piece, type: :model do
     it '#is_capturable? returns true if target can be captured' do
       game = FactoryBot.create(:game)
       piece = FactoryBot.build(:piece, game_id: game.id, x: 3, y: 3)
-      result = piece.is_capturable?(3, 7)
+      x_target = 3
+      y_target = 7
+      result = piece.is_capturable?(x_target, y_target)
+      piece_array = game.pieces.active.where({x: x_target, y: y_target})
+      target_piece = piece_array[0]
       expect(result).to eq true
     end
 
@@ -103,5 +107,23 @@ RSpec.describe Piece, type: :model do
       result = piece.is_capturable?(3, 2)
       expect(result).to eq false
     end
+
+    it '#captured! correctly updates "captured," "x," and "y" attributes if target is capturable' do
+      game = FactoryBot.create(:game)
+      piece = FactoryBot.build(:piece, game_id: game.id, x: 3, y: 3)
+      x_target = 3
+      y_target = 7
+      piece_array = game.pieces.active.where({x: x_target, y: y_target})
+      target_piece = piece_array[0]
+      piece.captured!(x_target, y_target)
+      target_piece.reload
+      expect(target_piece.captured).to eq true
+      expect(target_piece.x).to eq 0
+      expect(target_piece.y).to eq 0
+    end
+
+    xit '#captured! does not update target piece attributes if target is not capturable' do
+    end
+
   end
 end

--- a/spec/models/rook_spec.rb
+++ b/spec/models/rook_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Rook, type: :model do
 
     it '#is_move_valid? returns true if rook\'s move is valid' do
       game = FactoryBot.create(:game)
-      rook = FactoryBot.build(:rook, game_id: game.id)
+      rook = FactoryBot.build(:rook, game_id: game.id, x: 1, y: 3)
       result = rook.is_move_valid?(1, 7)
       expect(result).to eq true
     end
@@ -97,11 +97,11 @@ RSpec.describe Rook, type: :model do
   describe 'move result' do
     it 'updates :x and :y to x_target and y_target if move is valid' do
       game = FactoryBot.create(:game)
-      rook = FactoryBot.build(:rook, game_id: game.id)
-      rook.move_action(4, 1) # moves one square in 'y' direction
+      rook = FactoryBot.build(:rook, game_id: game.id, x: 1, y: 3)
+      rook.move_action(1, 7)
 
-      expect(rook.x).to eq 4
-      expect(rook.y).to eq 1
+      expect(rook.x).to eq 1
+      expect(rook.y).to eq 7
     end
 
     xit 'returns an "invalid move" message if move is invalid' do


### PR DESCRIPTION
Adds migration to add a default value of `false` to `captured` field on `pieces` table. Adds `#is_capturable?` logic and `#capture!` method for piece model. `#capture!` updates target piece attributes to `captured: true, x: 0, y: 0` which effectively removes it from the board. Special pawn capture logic not implemented.