### PR TITLE
More moving

### DIFF
--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -27,7 +27,7 @@ class PiecesController < ApplicationController
       @piece.move_action(x_target, y_target)
     end
     @piece.save
-    render plain: "Successful move"
+    render plain: "Success"
   end
 
   private

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -27,7 +27,7 @@ class PiecesController < ApplicationController
       @piece.move_action(x_target, y_target)
     end
     @piece.save
-    redirect_to game_path(@game)
+    render plain: "Successful move"
   end
 
   private

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -23,7 +23,7 @@ class PiecesController < ApplicationController
     y_target = piece_params[:y].to_i
     if @piece.is_capturable?(x_target, y_target)
       @piece.captured!(x_target, y_target)
-    else
+    elsif !@game.square_occupied?(x_target, y_target)
       @piece.move_action(x_target, y_target)
     end
     @piece.save

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -134,7 +134,7 @@ class Piece < ApplicationRecord
 
   #determines if the move is diagonal
   def diagonal_move?(x_target, y_target, x_current=self.x, y_current=self.y)
-    if (x_target - self.x).abs == (y_target - self.y).abs
+    if (x_target - x_current).abs == (y_target - y_current).abs
       return true
     else
       return false

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -4,502 +4,69 @@
 <head>
     <meta charset="UTF-8">
 </head>
+
 <body>
   <div class="chessboard">
 
-<!-- 1st -->
-
-    <div class="black">
-      <% piece = @game.pieces.active.where({x: 1, y: 8}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-      <!-- &#9820; -->
-    </div>
-
-
-    <div class="white">
-      <% piece = @game.pieces.active.where({x: 2, y: 8}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-      <!-- &#9822; -->
-    </div>
-
-    <div class="black">
-      <% piece = @game.pieces.active.where({x: 3, y: 8}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-      <!-- &#9821; -->
-    </div>
-
-    <div class="white">
-      <% piece = @game.pieces.active.where({x: 4, y: 8}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-      <!-- &#9819; -->
-    </div>
-
-    <div class="black">
-      <% piece = @game.pieces.active.where({x: 5, y: 8}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-      <!-- &#9818; -->
-    </div>
-
-    <div class="white">
-      <% piece = @game.pieces.active.where({x: 6, y: 8}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-      <!-- &#9821; -->
-    </div>
-
-    <div class="black">
-      <% piece = @game.pieces.active.where({x: 7, y: 8}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-      <!-- &#9822; -->
-    </div>
-
-    <div class="white">
-      <% piece = @game.pieces.active.where({x: 8, y: 8}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-      <!-- &#9820; -->
-    </div>
-
-    <!-- 2nd -->
-
-    <div class="white">
-      <% piece = @game.pieces.active.where({x: 1, y: 7}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-      <!-- &#9823; -->
-    </div>
-
-    <div class="black">
-      <% piece = @game.pieces.active.where({x: 2, y: 7}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-      <!-- &#9823; -->
-    </div>
-
-    <div class="white">
-      <% piece = @game.pieces.active.where({x: 3, y: 7}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-      <!-- &#9823; -->
-    </div>
-
-    <div class="black">
-      <% piece = @game.pieces.active.where({x: 4, y: 7}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-      <!-- &#9823; -->
-    </div>
-
-    <div class="white">
-      <% piece = @game.pieces.active.where({x: 5, y: 7}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-      <!-- &#9823; -->
-    </div>
-
-    <div class="black">
-      <% piece = @game.pieces.active.where({x: 6, y: 7}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-      <!-- &#9823; -->
-    </div>
-
-    <div class="white">
-      <% piece = @game.pieces.active.where({x: 7, y: 7}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-      <!-- &#9823; -->
-    </div>
-
-    <div class="black">
-      <% piece = @game.pieces.active.where({x: 8, y: 7}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-      <!-- &#9823; -->
-    </div>
-
-    <!-- 3th -->
-
-    <div class="black">
-      <% piece = @game.pieces.active.where({x: 1, y: 6}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-    </div>
-
-    <div class="white">
-      <% piece = @game.pieces.active.where({x: 2, y: 6}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-    </div>
-
-    <div class="black">
-      <% piece = @game.pieces.active.where({x: 3, y: 6}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-    </div>
-    <div class="white">
-      <% piece = @game.pieces.active.where({x: 4, y: 6}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-    </div>
-
-    <div class="black">
-      <% piece = @game.pieces.active.where({x: 5, y: 6}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-    </div>
-
-    <div class="white">
-      <% piece = @game.pieces.active.where({x: 6, y: 6}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-    </div>
-
-    <div class="black">
-      <% piece = @game.pieces.active.where({x: 7, y: 6}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-    </div>
-
-    <div class="white">
-      <% piece = @game.pieces.active.where({x: 8, y: 6}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-    </div>
-
-    <!-- 4st -->
-
-    <div class="white">
-      <% piece = @game.pieces.active.where({x: 1, y: 5}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-    </div>
-
-    <div class="black">
-      <% piece = @game.pieces.active.where({x: 2, y: 5}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-    </div>
-
-    <div class="white">
-      <% piece = @game.pieces.active.where({x: 3, y: 5}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-    </div>
-
-    <div class="black">
-      <% piece = @game.pieces.active.where({x: 4, y: 5}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-    </div>
-
-    <div class="white">
-      <% piece = @game.pieces.active.where({x: 5, y: 5}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-    </div>
-
-    <div class="black">
-      <% piece = @game.pieces.active.where({x: 6, y: 5}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-    </div>
-
-    <div class="white">
-      <% piece = @game.pieces.active.where({x: 7, y: 5}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-    </div>
-
-    <div class="black">
-      <% piece = @game.pieces.active.where({x: 8, y: 5}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-    </div>
-
-    <!-- 5th -->
-
-    <div class="black">
-      <% piece = @game.pieces.active.where({x: 1, y: 4}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-    </div>
-
-    <div class="white">
-      <% piece = @game.pieces.active.where({x: 2, y: 4}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-    </div>
-
-    <div class="black">
-      <% piece = @game.pieces.active.where({x: 3, y: 4}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-    </div>
-
-    <div class="white">
-      <% piece = @game.pieces.active.where({x: 4, y: 4}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-    </div>
-
-    <div class="black">
-      <% piece = @game.pieces.active.where({x: 5, y: 4}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-    </div>
-
-    <div class="white">
-      <% piece = @game.pieces.active.where({x: 6, y: 4}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-    </div>
-
-    <div class="black">
-      <% piece = @game.pieces.active.where({x: 7, y: 4}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-    </div>
-
-    <div class="white">
-      <% piece = @game.pieces.active.where({x: 8, y: 4}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-    </div>
-
-    <!-- 6th -->
-
-    <div class="white">
-      <% piece = @game.pieces.active.where({x: 1, y: 3}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-    </div>
-
-    <div class="black">
-      <% piece = @game.pieces.active.where({x: 2, y: 3}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-    </div>
-
-    <div class="white">
-      <% piece = @game.pieces.active.where({x: 3, y: 3}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-    </div>
-
-    <div class="black">
-      <% piece = @game.pieces.active.where({x: 4, y: 3}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-    </div>
-
-    <div class="white">
-      <% piece = @game.pieces.active.where({x: 5, y: 3}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-    </div>
-
-    <div class="black">
-      <% piece = @game.pieces.active.where({x: 6, y: 3}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-    </div>
-
-    <div class="white">
-      <% piece = @game.pieces.active.where({x: 7, y: 3}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-    </div>
-
-    <div class="black">
-      <% piece = @game.pieces.active.where({x: 8, y: 3}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-    </div>
-
-    <!-- 7th -->
-
-    <div class="black">
-      <% piece = @game.pieces.active.where({x: 1, y: 2}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece), method: :put %>
-      <% end %>
-      <!-- &#9817; -->
-    </div>
-
-    <div class="white">
-      <% piece = @game.pieces.active.where({x: 2, y: 2}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-      <!-- &#9817; -->
-    </div>
-
-    <div class="black">
-      <% piece = @game.pieces.active.where({x: 3, y: 2}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-      <!-- &#9817; -->
-    </div>
-
-    <div class="white">
-      <% piece = @game.pieces.active.where({x: 4, y: 2}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-      <!-- &#9817; -->
-    </div>
-
-    <div class="black">
-      <% piece = @game.pieces.active.where({x: 5, y: 2}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-      <!-- &#9817; -->
-    </div>
-
-    <div class="white">
-      <% piece = @game.pieces.active.where({x: 6, y: 2}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-      <!-- &#9817; -->
-    </div>
-
-    <div class="black">
-      <% piece = @game.pieces.active.where({x: 7, y: 2}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-      <!-- &#9817; -->
-    </div>
-
-    <div class="white">
-      <% piece = @game.pieces.active.where({x: 8, y: 2}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-      <!-- &#9817; -->
-    </div>
-
-    <!-- 8th -->
-
-    <div class="white">
-      <% piece = @game.pieces.active.where({x: 1, y: 1}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-      <!-- &#9814; -->
-    </div>
-
-    <div class="black">
-      <% piece = @game.pieces.active.where({x: 2, y: 1}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-      <!-- &#9816; -->
-    </div>
-
-    <div class="white">
-      <% piece = @game.pieces.active.where({x: 3, y: 1}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-      <!-- &#9815; -->
-    </div>
-
-    <div class="black">
-      <% piece = @game.pieces.active.where({x: 4, y: 1}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-      <!-- &#9813; -->
-    </div>
-
-    <div class="white">
-      <% piece = @game.pieces.active.where({x: 5, y: 1}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-      <!-- &#9812; -->
-    </div>
-
-    <div class="black">
-      <% piece = @game.pieces.active.where({x: 6, y: 1}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-      <!-- &#9815; -->
-    </div>
-    <div class="white">
-      <% piece = @game.pieces.active.where({x: 7, y: 1}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-      <!-- &#9816; -->
-    </div>
-    <div class="black">
-      <% piece = @game.pieces.active.where({x: 8, y: 1}).first %>
-      <% if piece != nil %>
-        <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-      <% end %>
-      <!-- &#9814; -->
-    </div>
-</div>
+    <% for row in (1..8) %> <!-- loops through the rows in the gameboard -->
+      <% for col in (1..8) %> <!-- loops through the columns -->
+        <div class="square"
+           data-x=<%= "#{col}" %>
+           data-y=<%= "#{9 - row}" %>
+           <% piece = @game.pieces.active.find_by( { x: col , y: 9 - row } ) %>
+           data-piece-id=
+           <% if piece != nil %>
+             "<%= piece.id %>"
+           <% end %>
+           >
+          <div class=
+          <% if row % 2 != 0 %>
+            <%= col % 2 != 0 ? "black" : "white" %>
+          <% else %>
+            <%= col % 2 == 0 ? "black" : "white" %>
+          <% end %>
+          >
+            <% if piece != nil %>
+              <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
+            <% end %>
+          <!-- end of div loop for determining square color -->
+        <!-- &#9820; -->
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+
+    <!-- end of experiment -->
+  </div>
 </body>
+
+<script>
+  $(function() {
+    var square = $('.square');
+
+
+
+    square.click( function() {
+      var xPosition = $(this).data('x');
+      var yPosition = $(this).data('y');
+      var clickedSquare = $(this).data('piece-id');
+      var selectedPiece = $('.selected').data('piece-id');
+
+      if (selectedPiece != '') {
+        $.ajax({
+          type: 'PATCH',
+          url: '/pieces/' + selectedPiece,
+          // dataType: 'json',
+          data: { piece: { x: xPosition, y: yPosition } },
+          success: function(){
+            console.log('success');
+          }
+        });
+        
+      }
+
+      selectedPiece.toggleClass('selected');
+
+    });
+  });
+</script>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -45,6 +45,8 @@
       var xPosition = $(this).data('x');
       var yPosition = $(this).data('y');
       var isPieceSelected = square.hasClass('selected');
+      var selectedSquareWhite = $('.selected .white');
+      var selectedSquareBlack = $('.selected .black');
       var selectedPiece = $('.selected').data('piece-id');
 
       if (isPieceSelected && !($('.selected').data('x') === xPosition && $('.selected').data('y') === yPosition)) {
@@ -53,9 +55,19 @@
 
       if (!isPieceSelected && $(this).data('piece-id')) {
         $(this).addClass('selected');
+        var selectedSquareWhite = $('.selected .white');
+        var selectedSquareBlack = $('.selected .black');
+        selectedSquareWhite.css('font-weight', 'bold');
+        selectedSquareBlack.css('font-weight', 'bold');
+        selectedSquareWhite.css('background', 'yellow');
+        selectedSquareBlack.css('background', 'yellow');
       }
       else {
         $(this).removeClass('selected');
+        selectedSquareWhite.css('font-weight', 'normal');
+        selectedSquareBlack.css('font-weight', 'normal');
+        selectedSquareWhite.css('background', '#fff');
+        selectedSquareBlack.css('background', '#999');
       }
 
       function updatePiece() {

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -27,16 +27,13 @@
           <% end %>
           >
             <% if piece != nil %>
-              <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
+              <%= "#{piece.color} #{piece.type}" %>
             <% end %>
           <!-- end of div loop for determining square color -->
-        <!-- &#9820; -->
           </div>
         </div>
       <% end %>
     <% end %>
-
-    <!-- end of experiment -->
   </div>
 </body>
 
@@ -44,29 +41,33 @@
   $(function() {
     var square = $('.square');
 
-
-
     square.click( function() {
       var xPosition = $(this).data('x');
       var yPosition = $(this).data('y');
-      var clickedSquare = $(this).data('piece-id');
+      var isPieceSelected = square.hasClass('selected');
       var selectedPiece = $('.selected').data('piece-id');
 
-      if (selectedPiece != '') {
+      if (isPieceSelected && !($('.selected').data('x') === xPosition && $('.selected').data('y') === yPosition)) {
+        updatePiece();
+      }
+
+      if (!isPieceSelected && $(this).data('piece-id')) {
+        $(this).addClass('selected');
+      }
+      else {
+        $(this).removeClass('selected');
+      }
+
+      function updatePiece() {
         $.ajax({
           type: 'PATCH',
           url: '/pieces/' + selectedPiece,
-          // dataType: 'json',
           data: { piece: { x: xPosition, y: yPosition } },
           success: function(){
-            console.log('success');
+            location.reload();
           }
         });
-        
       }
-
-      selectedPiece.toggleClass('selected');
-
     });
   });
 </script>

--- a/app/views/pieces/show.html.erb
+++ b/app/views/pieces/show.html.erb
@@ -49,7 +49,7 @@
       $.ajax({
         type: 'PATCH',
         url: $(this).data('update-url'),
-        dataType: 'json',
+        // dataType: 'json',
         data: { piece: { x: xPosition, y: yPosition } },
         success: function(){
           console.log('success');

--- a/app/views/pieces/show.html.erb
+++ b/app/views/pieces/show.html.erb
@@ -6,69 +6,7 @@
 </head>
 
 <body>
-  <div class="chessboard">
-
-    <% for row in (1..8) %> <!-- loops through the rows in the gameboard -->
-      <% for col in (1..8) %> <!-- loops through the columns -->
-        <div class="square"
-           data-x=<%= "#{col}" %>
-           data-y=<%= "#{9 - row}" %>
-           data-update-url="<%= piece_path(@piece) %>">
-          <div class=
-          <% if row % 2 != 0 %>
-            <%= col % 2 != 0 ? "black" : "white" %>
-          <% else %>
-            <%= col % 2 == 0 ? "black" : "white" %>
-          <% end %>
-          >
-            <% piece = @pieces.active.find_by( { x: col , y: 9 - row } ) %>
-            <% if piece == nil %>
-              <%= link_to "____", game_path(@game) %>
-            <% elsif piece.id == @piece.id %>
-              <b><%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %></b>
-            <% else %>
-              <%= link_to "#{piece.color} #{piece.type}", piece_path(piece) %>
-            <% end %>
-          <!-- end of div loop for determining square color -->
-        <!-- &#9820; -->
-          </div>
-        </div>
-      <% end %>
-    <% end %>
-
-    <!-- end of experiment -->
+  <div class="black">
+    <%= "#{@piece.color} #{@piece.type}" %>
   </div>
 </body>
-
-<script>
-  $(function() {
-    var square = $('.square');
-    square.click( function() {
-      var xPosition = $(this).data('x');
-      var yPosition = $(this).data('y');
-      $.ajax({
-        type: 'PATCH',
-        url: $(this).data('update-url'),
-        // dataType: 'json',
-        data: { piece: { x: xPosition, y: yPosition } },
-        success: function(){
-          console.log('success');
-        }
-      });
-
-    });
-  });
-
-  // $(function() {
-  //   $('#square').click({
-  //     update: function( event ) {
-  //       $.ajax({
-  //         type: 'PUT',
-  //         url: $(event.target).data('update-url'),
-  //         dataType: 'json',
-  //         data: { piece: { x: $(event.target).data('data-x'), y: $(event.target).data('data-y') } }
-  //       });
-  //     }
-  //   });
-  // });
-</script>

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe PiecesController, type: :controller do
       sign_in game.user
       put :update, params: { id: piece.id, piece: { x: 1, y: 3 } }
       # response_value = ActiveSupport::JSON.decode(@response.body)
-      expect(response).to redirect_to game_path(game)
+      expect(response).to have_http_status :success
       piece.reload
       # expect(response_value['x']).to eq(1)
       # expect(response_value['y']).to eq(3)

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -4,7 +4,7 @@ require 'pry'
 RSpec.describe PiecesController, type: :controller do
 
   describe 'pieces#show action' do
-    it 'should successfully return the correct piece id if the piece is found' do
+    it 'should have http status "success" if the piece is found' do
       game = FactoryBot.create(:game)
       piece = FactoryBot.create(:piece, game_id: game.id)
       sign_in game.user
@@ -44,20 +44,24 @@ RSpec.describe PiecesController, type: :controller do
   describe 'pieces#update action' do
     it 'should correctly update the piece\'s :x and :y if the move is valid' do
       game = FactoryBot.create(:game)
-      piece = game.pieces.active.where({x: 1, y: 2}).first
+      piece = game.pieces.active.find_by({x: 1, y: 2})
       sign_in game.user
-      put :update, params: { id: piece.id, piece: { x: 1, y: 3 } }
-      # response_value = ActiveSupport::JSON.decode(@response.body)
+      patch :update, params: { id: piece.id, piece: { x: 1, y: 3 } }
       expect(response).to have_http_status :success
       piece.reload
-      # expect(response_value['x']).to eq(1)
-      # expect(response_value['y']).to eq(3)
       expect(piece.x).to eq(1)
       expect(piece.y).to eq(3)
     end
 
-    xit 'should not update the piece\'s :x and :y if the move is not valid' do
-
+    it 'should not update the piece\'s :x and :y if the move is not valid' do
+      game = FactoryBot.create(:game)
+      piece = game.pieces.active.find_by({x: 1, y: 2})
+      sign_in game.user
+      patch :update, params: { id: piece.id, piece: { x: 1, y: 5 } }
+      expect(response).to have_http_status :success
+      piece.reload
+      expect(piece.x).to eq(1)
+      expect(piece.y).to eq(2)
     end
   end
 end


### PR DESCRIPTION
Cleans up piece movement. No longer requires switching back and forth between game show page and piece show page. Everything is handled on game show page now, with no page refresh needed. The selected piece is highlighted by turning the square yellow. Piece can be deselected as well. This PR also fixes a couple of movement logic "glitches" we came across. Adds a test for the pieces#update action.