### PR TITLE
Turn logic

### DIFF
--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -7,7 +7,8 @@ class PiecesController < ApplicationController
     if @piece.blank?
       return render_not_found
     end
-    if @piece.piece_color_matches_user_color?(current_user)
+    @game = @piece.game
+    if @piece.piece_color_matches_user_color?(current_user) && @game.is_player_turn?(current_user)
       return render plain: "Success"
     else
       render_not_found

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -21,6 +21,7 @@ class PiecesController < ApplicationController
     y_target = piece_params[:y].to_i
     if @piece.attempt_move(x_target, y_target)
       @piece.save
+      @game.player_turn
     else
       return render_not_found
     end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -35,7 +35,7 @@ class Game < ApplicationRecord
     end
   end
 
-  def is_players_turn?(user)
+  def is_player_turn?(user)
     if self.state == "white_turn" && user.id == white_player_id
       true
     elsif self.state == "black_turn" && user.id == black_player_id

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -9,16 +9,12 @@ class Game < ApplicationRecord
 
   before_create :current_user_is_white_player
 
-
-  # to initialize each game with the white_player as the user who created the game
-  # white_player_id needs to exist in the database
-
   def square_occupied?(x_current, y_current)
     pieces.active.where({x: x_current, y: y_current}).any? ? true : false
   end
 
-  def add_black_player!(player)
-    self.black_player_id = player.id
+  def add_black_player!(user)
+    self.black_player_id = user.id
     self.total_players = 2
     save
   end
@@ -39,18 +35,31 @@ class Game < ApplicationRecord
     end
   end
 
+  def is_players_turn?(user)
+    if self.state == "white_turn" && user.id == white_player_id
+      true
+    elsif self.state == "black_turn" && user.id == black_player_id
+      true
+    else
+      false
+    end   
+  end
+
+  def player_turn
+    if self.state == "white_turn"
+      self.state = "black_turn"
+      save
+    elsif self.state == "black_turn"
+      self.state = "white_turn"
+      save
+    end
+  end
+
   private
 
   def start_game_when_black_player_is_added
     self.state = "white_turn" if state == "pending" && black_player_id.present?
   end
-  
-  def player_turn
-   #need to add state change for when the players turn changes.  
-  end
-  
-
-
 
   def populate
     (1..8).each do |piece|

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -53,19 +53,12 @@
 
       // If no square is selected and a piece is present, the clicked square will become selected
       if (!$isPieceSelected && $(this).attr('data-piece-id')) {
-        //need to check if piece color and player color match here
-        // $.get('/pieces/' + $targetPiece).success( function() {
-        //   $(this).addClass('selected');
-        // });
-
         // Before turn order has been implemented, after a piece is moved it's not able to be
         // selected again. Other pieces (of the correct color) can be selected though.
         // The piece ID isn't getting passed to the URL on the failing GET request.
         $.get('/pieces/' + $targetPiece, function() {
           $targetSquare.addClass('selected');
         });
-
-        // moveOwnColor();
       }
       // If a square is already selected, the click will remove the selection
       else {
@@ -87,16 +80,6 @@
           }
         });
       }
-
-      // function moveOwnColor() {
-      //   $.ajax({
-      //     type: 'GET',
-      //     url: '/pieces/' + $targetPiece,
-      //     success: function(){
-      //       $targetSquare.addClass('selected');
-      //     }
-      //   });
-      // }
     });
   });
 </script>

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -40,10 +40,12 @@ RSpec.describe PiecesController, type: :controller do
       expect(response).to have_http_status :not_found
     end
 
-    it 'should return success if the piece color matches the user color' do
+    it 'should return success if the piece color matches the user color and it\'s the correct user\'s turn' do
       game = FactoryBot.create(:game)
       piece = game.pieces.active.find_by({x: 1, y: 2})
       sign_in game.user
+      game.state = "white_turn"
+      game.save
       get :show, params: { id: piece.id }
       expect(response).to have_http_status :success
     end

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -79,5 +79,27 @@ RSpec.describe PiecesController, type: :controller do
       expect(piece.x).to eq(1)
       expect(piece.y).to eq(2)
     end
+
+    it 'should change the game state to reflect the correct player\'s turn' do
+      game = FactoryBot.create(:game)
+      piece = game.pieces.active.find_by({x: 1, y: 2})
+      sign_in game.user
+      game.state = "white_turn"
+      game.save
+      patch :update, params: { id: piece.id, piece: { x: 1, y: 3 } }
+      game.reload
+      expect(game.state).to eq("black_turn")
+    end
+
+    it 'player\'s turn should not change if the move was unsuccessful' do
+      game = FactoryBot.create(:game)
+      piece = game.pieces.active.find_by({x: 1, y: 2})
+      sign_in game.user
+      game.state = "white_turn"
+      game.save
+      patch :update, params: { id: piece.id, piece: { x: 1, y: 5 } }
+      game.reload
+      expect(game.state).to eq("white_turn")
+    end
   end
 end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -73,19 +73,67 @@ RSpec.describe Game, type: :model do
     end
   end
   
-  describe 'game states' do 
-      it "upon game creation the state should be pending" do
-        game=FactoryBot.create :game 
-        expect(game.state).to eq("pending")
-      end
-      
-      xit "when the second player joins game state changes to active" do
-        game=FactoryBot.create :game 
-        #test joining once that functionality is created.
-        expect(game.state).to eq("white_turn")
-      end
+  describe 'game states' do
+    it "upon game creation the state should be pending" do
+      game=FactoryBot.create :game 
+      expect(game.state).to eq("pending")
+    end
+
+    it "when black player joins, the game state should be white_turn" do
+      game = FactoryBot.create(:game)
+      new_user = FactoryBot.create(:user) 
+      game.black_player_id = new_user.id
+      game.save
+      expect(game.state).to eq("white_turn")
+    end
+
+    it "after a white player completes their turn, the game state should be black_turn" do
+      game = FactoryBot.create(:game)
+      new_user = FactoryBot.create(:user)
+      game.black_player_id = new_user.id
+      game.save
+      game.player_turn
+      game.reload
+      expect(game.state).to eq("black_turn")
+    end
+
+    it "after a black player completes their turn, the game state should be white_turn" do
+      game = FactoryBot.create(:game)
+      new_user = FactoryBot.create(:user)
+      game.black_player_id = new_user.id
+      game.save
+      game.player_turn
+      game.player_turn
+      expect(game.state).to eq("white_turn")
+    end
+
+    it "should return true if the state is 'white_turn' and the current user is the white player" do
+      game = FactoryBot.create(:game)
+      user = game.user
+      game.state = "white_turn"
+      result = game.is_players_turn?(user)
+      expect(result).to eq true
+    end
+
+    it "should return true if the state is 'black_turn' and the current user is the black player" do
+      game = FactoryBot.create(:game)
+      new_user = FactoryBot.create(:user)
+      game.black_player_id = new_user.id
+      game.save
+      game.player_turn
+      result = game.is_players_turn?(new_user)
+      expect(result).to eq true
+    end
+
+    it "should return false if it's not the player's turn" do
+      game = FactoryBot.create(:game)
+      new_user = FactoryBot.create(:user)
+      game.black_player_id = new_user.id
+      game.save
+      result = game.is_players_turn?(new_user)
+      expect(result).to eq false
+    end
   end
-  
 
   describe 'available' do
     it 'should show available games, which are games with total_players = 1' do
@@ -105,22 +153,12 @@ RSpec.describe Game, type: :model do
       game = FactoryBot.create(:game)
       expect(game.black_player_id).to eq nil
     end
-    
-    context "when black player joins" do
-      it "should be white_turn" do
-        game = FactoryBot.create(:game)
-        new_user = FactoryBot.create(:user) 
-        game.black_player_id = new_user.id
-        game.save
-        expect(game.state).to eq("white_turn")
-      end
 
-      it "should update total_players to 2" do
-        game = FactoryBot.create(:game)
-        new_user = FactoryBot.create(:user) 
-        game.add_black_player!(new_user)
-        expect(game.total_players).to eq(2)
-      end
+    it "should update total_players to 2" do
+      game = FactoryBot.create(:game)
+      new_user = FactoryBot.create(:user) 
+      game.add_black_player!(new_user)
+      expect(game.total_players).to eq(2)
     end
   end
 

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Game, type: :model do
       game = FactoryBot.create(:game)
       user = game.user
       game.state = "white_turn"
-      result = game.is_players_turn?(user)
+      result = game.is_player_turn?(user)
       expect(result).to eq true
     end
 
@@ -121,7 +121,7 @@ RSpec.describe Game, type: :model do
       game.black_player_id = new_user.id
       game.save
       game.player_turn
-      result = game.is_players_turn?(new_user)
+      result = game.is_player_turn?(new_user)
       expect(result).to eq true
     end
 
@@ -130,7 +130,7 @@ RSpec.describe Game, type: :model do
       new_user = FactoryBot.create(:user)
       game.black_player_id = new_user.id
       game.save
-      result = game.is_players_turn?(new_user)
+      result = game.is_player_turn?(new_user)
       expect(result).to eq false
     end
   end


### PR DESCRIPTION
Game state is updated to reflect either "white_turn" or "black_turn", players can only move their matching pieces if it is their turn. Player turn switches when a move is executed successfully.